### PR TITLE
pki (mTLS) cert load testing only

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -1,17 +1,28 @@
-from locusts.key_value import KeyValueLocust
-from locusts.transit import TransitLocust
+#from locusts.pki_short_ttl import PkiShortTTLLocust
 from locusts.pki import PkiLocust
-from locusts.dyn_mongodb import MongoDbLocust
-from locusts.dyn_mysql import MysqlLocust
-from locusts.totp import TotpLocust
-from locusts.auth_userpass import UserPassAuthLocust
-from locusts.auth_approle import AppRoleLocust
+import urllib3
+urllib3.disable_warnings()
 
-__static__ = [KeyValueLocust, TransitLocust, PkiLocust]
-__dynamic__ = [MysqlLocust, MongoDbLocust, TotpLocust]
-__auth__ = [UserPassAuthLocust, AppRoleLocust]
+# from locusts.key_value import KeyValueLocust
+#from locusts.token import TokenLocust
+# from locusts.transit import TransitLocust
+# from locusts.dyn_mongodb import MongoDbLocust
+# from locusts.dyn_mysql import MysqlLocust
+# from locusts.totp import TotpLocust
+# from locusts.auth_userpass import UserPassAuthLocust
+# from locusts.auth_approle import AppRoleLocust
 
-__all__ = __static__ + __dynamic__ + __auth__
+__all__ = [PkiLocust]
+# __all__ = [PkiLocust, PkiShortTTLLocust]
+#__all__ = [PkiShortTTLLocust]
+#__all__ = [KeyValueLocust, PkiLocust]
+#__all__ = [KeyValueLocust, PkiLocust, TokenLocust]
+
+# __static__ = [KeyValueLocust, TransitLocust, PkiLocust]
+# __dynamic__ = [MysqlLocust, MongoDbLocust, TotpLocust]
+# __auth__ = [UserPassAuthLocust, AppRoleLocust]
+
+# __all__ = __static__ + __dynamic__ + __auth__
 
 # import logging
 # logging.getLogger().setLevel(logging.DEBUG)

--- a/locusts/__init__.py
+++ b/locusts/__init__.py
@@ -32,13 +32,14 @@ class VaultLocust(HttpLocust):
 
 class VaultTaskSet(TaskSet):
 
-    def mount(self, name: str, mount_point: str=None):
+    def mount(self, name: str, mount_point: str = None):
         mount_point = mount_point or name
         r = self.client.get('/v1/sys/mounts')
         if f'{mount_point}/' not in r.json():
-            self.client.post(f'/v1/sys/mounts/{mount_point}', json={'type': name})
+            self.client.post(
+                f'/v1/sys/mounts/{mount_point}', json={'type': name})
 
-    def enable_auth(self, name: str, path: str=None):
+    def enable_auth(self, name: str, path: str = None):
         path = path or name
         r = self.client.get('/v1/sys/auth')
         if f'{path}/' not in r.json():
@@ -54,6 +55,7 @@ class VaultTaskSet(TaskSet):
                 r.success()
                 return False
             else:
+                print(r.json())
                 return key in r.json()['data']['keys']
 
     @property
@@ -83,14 +85,17 @@ class VaultSession(HttpSession):
         response = self._send_request_safe_mode(method, url, **kwargs)
 
         # record the consumed time
-        request_meta["response_time"] = int((time.time() - request_meta["start_time"]) * 1000)
+        request_meta["response_time"] = int(
+            (time.time() - request_meta["start_time"]) * 1000)
 
-        request_meta["name"] = name or (response.history and response.history[0] or response).request.path_url
+        request_meta["name"] = name or (
+            response.history and response.history[0] or response).request.path_url
 
         # get the length of the content, but if the argument stream is set to True, we take
         # the size from the content-length header, in order to not trigger fetching of the body
         if kwargs.get("stream", False):
-            request_meta["content_size"] = int(response.headers.get("content-length") or 0)
+            request_meta["content_size"] = int(
+                response.headers.get("content-length") or 0)
         else:
             request_meta["content_size"] = len(response.content or "")
 
@@ -102,7 +107,8 @@ class VaultSession(HttpSession):
                 response.raise_for_status()
             except RequestException as e:
                 try:
-                    e = CatchResponseError('. '.join(response.json()['errors']))
+                    e = CatchResponseError(
+                        '. '.join(response.json()['errors']))
                 except KeyError:
                     e = CatchResponseError(e)
                 except json.JSONDecodeError:

--- a/locusts/pki.py
+++ b/locusts/pki.py
@@ -12,9 +12,9 @@ class PkiTasks(VaultTaskSet):
     ROLE_NAME = 'test-pki-role'
 
     def setup(self):
-        self.mount('pki')
-        self.client.post('/v1/pki/root/generate/internal',
-                         json={'common_name': self.DOMAIN_NAME, 'ttl': '8760h'})
+        #self.mount('pki')
+        #self.client.post('/v1/pki/root/generate/internal',
+        #                 json={'common_name': self.DOMAIN_NAME, 'ttl': '8760h'})
         self.create_role()
 
     def teardown(self):
@@ -25,7 +25,7 @@ class PkiTasks(VaultTaskSet):
             self.delete_role()
         self.client.post(f'/v1/pki/roles/{self.ROLE_NAME}',
                          json={'allowed_domains': self.DOMAIN_NAME,
-                               'max_ttl': '72h',
+                               'max_ttl': '2h',
                                'allow_subdomains': True})
 
     def delete_role(self):
@@ -33,12 +33,14 @@ class PkiTasks(VaultTaskSet):
 
     @task
     def generate_cert(self):
-        self.client.post('/v1/pki/issue/test-pki-role',
+        self.client.post(f'/v1/pki/issue/{self.ROLE_NAME}',
                          json={'common_name': f'foo.{self.DOMAIN_NAME}'})
 
 
 class PkiLocust(VaultLocust):
     task_set = PkiTasks
     weight = 1
-    min_wait = 5000
-    max_wait = 10000
+    # min_wait = 60000
+    # max_wait = 60000*5
+    min_wait = 100
+    max_wait = 1000


### PR DESCRIPTION
This is a personal fork that focuses only on load-testing the PKI
backend. All of the other loadtests such as the KV, mysql, and transit backends are disabled.
This also means you can avoid some of the setup around seeding initial
secrets.

There is also some code that can be uncommented/commented if you want to
test a certificate role with generate_lease=false/no_store=true